### PR TITLE
Add -G flag to enable UDP segment offload in Linux.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -124,5 +124,14 @@ test-write:
 	    wait $$!
 	grep -q 'recv: syscalls ' out
 
+TEST += gro
+test-gro:
+	@echo -e '\n==== $@ ===='
+	./udpbench -p0 -G -t3 recv 127.0.0.1 >out & \
+	    sleep 1; \
+	    port=`awk '/^sockname:/{print $$3}' out`; \
+	    ./udpbench -p$$port -t1 -G -m1 send 127.0.0.1 || exit 1; \
+	    wait $$!
+
 .PHONY: test $(patsubst %,test-%,$(TEST))
 test: $(patsubst %,test-%,$(TEST))

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -127,10 +127,10 @@ test-write:
 TEST += gro
 test-gro:
 	@echo -e '\n==== $@ ===='
-	./udpbench -p0 -G -t3 recv 127.0.0.1 >out & \
+	./udpbench -p0 -l1470 -G -m1 -t3 recv 127.0.0.1 >out & \
 	    sleep 1; \
 	    port=`awk '/^sockname:/{print $$3}' out`; \
-	    ./udpbench -p$$port -t1 -G -m1 send 127.0.0.1 || exit 1; \
+	    ./udpbench -p$$port -t1 -l1470 -G -m1 send 127.0.0.1 || exit 1; \
 	    wait $$!
 
 .PHONY: test $(patsubst %,test-%,$(TEST))

--- a/udpbench.1
+++ b/udpbench.1
@@ -23,7 +23,7 @@
 .Sh SYNOPSIS
 .Nm
 .Bk -words
-.Op Fl DHw
+.Op Fl DGHw
 .Op Fl B Ar bitrate
 .Op Fl b Ar bufsize
 .Op Fl d Ar delay
@@ -97,6 +97,17 @@ Sleep some seconds before sending packets with payload.
 This is useful to wait for setup of multiple processes via ssh.
 An initial empty packet is sent before delay to trigger setup.
 Default is 0 seconds which disables the feature.
+.It Fl G
+Use UDP send and receive offload.
+This requires setting 
+.Fl m Ar mmsglen
+and
+.Fl l Ar length
+greater than 0.
+This option is only available on systems that define
+.Dv UDP_SEGMENT
+and 
+.Dv UDP_GSO.
 .It Fl H
 Use IPv6 hop-by-hop option by adding a router alert when sending.
 .It Fl I Ar ifaddr

--- a/udpbench.c
+++ b/udpbench.c
@@ -905,14 +905,12 @@ mmsg_alloc(int packets, size_t paylen, int fill)
 	struct mmsghdr *mmsg, *mhdr;
 	struct iovec *iov;
 	char *payload;
-#if defined(__linux__) && defined(UDP_SEGMENT)
+#if defined(__linux__) && (defined(UDP_GRO) || defined(UDP_SEGMENT))
 	char *cmsgs;
 	struct cmsghdr *cmsg;
 	size_t cmsg_size;
 	uint16_t gso_size = paylen & 0xffff;
-#endif
 
-#if defined(__linux__) && (defined(UDP_GRO) || defined(UDP_SEGMENT))
 	if (segment) {
 		if (fill) {
 			if (IP_MAXPACKET / paylen >= 126) 
@@ -952,7 +950,7 @@ mmsg_alloc(int packets, size_t paylen, int fill)
 		mhdr->msg_hdr.msg_iovlen = 1;
 		iov->iov_base = payload;
 		iov->iov_len = paylen;
-#if defined(__linux__) && defined(UDP_SEGMENT)
+#if defined(__linux__) && (defined (UDP_GRO) || defined(UDP_SEGMENT))
 		if (segment) {
 			mhdr->msg_hdr.msg_control = cmsgs;
 			mhdr->msg_hdr.msg_controllen = cmsg_size;

--- a/udpbench.c
+++ b/udpbench.c
@@ -893,7 +893,9 @@ mmsg_alloc(int packets, size_t paylen, int fill)
 	struct cmsghdr *cmsg;
 	size_t cmsg_size;
 	uint16_t gso_size = paylen & 0xffff;
+#endif
 
+#if defined(__linux__) && (defined(UDP_GRO) || defined(UDP_SEGMENT))
 	if (segment) {
 		if (fill)
 		    paylen = (IP_MAXPACKET / paylen) * paylen;

--- a/udpbench.c
+++ b/udpbench.c
@@ -935,7 +935,7 @@ mmsg_alloc(int packets, size_t paylen, int fill)
 	if (fill)
 		arc4random_buf(payload, packets * paylen);
 
-#if defined(__linux__) && defined(UDP_SEGMENT)
+#if defined(__linux__) && (defined (UDP_GRO) || defined(UDP_SEGMENT))
 	if (segment) {
 		if (fill)
 			cmsg_size = CMSG_SPACE(sizeof(uint16_t));
@@ -983,7 +983,7 @@ mmsg_free(struct mmsghdr *mmsg)
 {
 	free(mmsg->msg_hdr.msg_iov->iov_base);
 	free(mmsg->msg_hdr.msg_iov);
-#if defined(__linux__) && defined(UDP_SEGMENT)
+#if defined(__linux__) && (defined(UDP_GRO) || defined(UDP_SEGMENT))
 	free(mmsg->msg_hdr.msg_control);
 #endif
 	free(mmsg);

--- a/udpbench.c
+++ b/udpbench.c
@@ -915,7 +915,7 @@ mmsg_alloc(int packets, size_t paylen, int fill)
 #if defined(__linux__) && (defined(UDP_GRO) || defined(UDP_SEGMENT))
 	if (segment) {
 		if (fill) {
-			if ((IP_MAXPACKET / paylen) >= 126) 
+			if (IP_MAXPACKET / paylen >= 126) 
 				paylen = 125 * paylen;
 			else
 				paylen = (IP_MAXPACKET / paylen) * paylen;
@@ -1032,8 +1032,12 @@ udp_send(int udp_socket, int udp_family, unsigned long sendrate)
 			err(1, "send");
 		}
 #if defined(__linux__) && defined(UDP_SEGMENT)
-		if (segment)
-			pkts *= (IP_MAXPACKET / udplen);
+		if (segment) {
+			if (IP_MAXPACKET / udplen >= 126)
+				pkts *= 125;
+			else
+				pkts *= IP_MAXPACKET / udplen;
+		}
 #endif
 		packet += pkts;
 		if (sendrate) {

--- a/udpbench.c
+++ b/udpbench.c
@@ -913,7 +913,7 @@ mmsg_alloc(int packets, size_t paylen, int fill)
 
 	if (segment) {
 		if (fill) {
-			if (IP_MAXPACKET / paylen >= 126) 
+			if (IP_MAXPACKET / paylen >= 126)
 				paylen *= 125;
 			else
 				paylen *= IP_MAXPACKET / paylen;
@@ -937,7 +937,7 @@ mmsg_alloc(int packets, size_t paylen, int fill)
 	if (segment) {
 		if (fill)
 			cmsg_size = CMSG_SPACE(sizeof(uint16_t));
-		else 
+		else
 			cmsg_size = CMSG_SPACE(sizeof(int));
 		if ((cmsgs = calloc(packets, cmsg_size)) == NULL)
 		    err(1, "calloc cmsgs");

--- a/udpbench.c
+++ b/udpbench.c
@@ -916,9 +916,9 @@ mmsg_alloc(int packets, size_t paylen, int fill)
 	if (segment) {
 		if (fill) {
 			if (IP_MAXPACKET / paylen >= 126) 
-				paylen = 125 * paylen;
+				paylen *= 125;
 			else
-				paylen = (IP_MAXPACKET / paylen) * paylen;
+				paylen *= IP_MAXPACKET / paylen;
 		} else
 			paylen = IP_MAXPACKET;
 	}


### PR DESCRIPTION
The patch below can enable GRO on Linux (https://lwn.net/Articles/768995/, https://lwn.net/ml/netdev/a8112a7fbbfc39d5b59e5ace0d3c1409824f9261.1539957909.git.pabeni@redhat.com/).
I noticed that it only needs a sockopt and that udpbench does not
need many additional changes to cope with the changes in receive
behavior.

GRO:
```
root@t0:~/udpbench# ./udpbench -r root@t1 -R /root/udpbench/udpbench -G -m 1024 -t 10 -b 655350000 -l 1420 recv 10.0.0.1
sockname: 10.0.0.1 12345
peername: 10.0.0.2 34723
send: syscalls 4930, packets 5048320, frame 1, payload 1420, ip 1448, ether 1486, begin 1744804762.685554, end 1744804772.682420, duration 9.996866, bit/s 6.003324e+09, start 1744804762.681582, stop 1744804772.682526
recv: syscalls 199, packets 5047393, frame 1, payload 1420, ip 1448, ether 1486, begin 1744804762.686053, end 1744804772.790384, duration 10.104331, bit/s 5.938385e+09, start 1744804761.240173, stop 1744804773.931088
```

NO GRO:
```
root@t0:~/udpbench# ./udpbench -r root@t1 -R /root/udpbench/udpbench -m 1024 -t 10 -b 655350000 -l 1420 recv 10.0.0.1
sockname: 10.0.0.1 12345
peername: 10.0.0.2 43523
send: syscalls 4895, packets 5012480, frame 1, payload 1420, ip 1448, ether 1486, begin 1744804969.817430, end 1744804979.815481, duration 9.998051, bit/s 5.959998e+09, start 1744804969.813364, stop 1744804979.815601
recv: syscalls 4906, packets 5011369, frame 1, payload 1420, ip 1448, ether 1486, begin 1744804969.817863, end 1744804979.922393, duration 10.104530, bit/s 5.895886e+09, start 1744804968.007205, stop 1744804981.062712
```

Currently the bitrate calculation is hacky with GRO, it takes the
total received payload and divides it by the rcvlen to get the
number of packets.
By using the UDP_GRO cmsg_type one supposedly could get back the
individual packet size and then divide for each msg in mmsg:
` if(cmsg->cmsg_level == SOL_UDP && cmsg->cmsg_type == UDP_GRO) { ...`

However, I cannot get it to work. Below is my attempted diff for
that:
```
--- udpbench.c	2025-04-16 14:11:25.960592761 +0200
+++ udpbench-gro-cmsg.c	2025-04-16 13:58:25.024956595 +0200
@@ -67,6 +67,7 @@
 void	udp_setbuffersize(int, int, int);
 #if defined(__linux__) && defined(UDP_GRO)
 void	udp_setgro(int);
+int	getgro_size(struct msghdr *msg);
 #endif
 void	udp_setrouteralert(int);
 void	udp_send(int, int, unsigned long);
@@ -846,6 +847,22 @@
 	if (setsockopt(udp_socket, IPPROTO_UDP, UDP_GRO, &on, len) == -1)
 		err(1, "setsockopt gro");
 }
+
+int
+getgro_size(struct msghdr *msg)
+{
+	struct cmsghdr *cmsg;
+	int pktsz = 0;
+
+	for(cmsg = CMSG_FIRSTHDR(msg); cmsg; cmsg = CMSG_NXTHDR(msg, cmsg)) {
+		if(cmsg->cmsg_level == SOL_UDP && cmsg->cmsg_type == UDP_GRO) {
+			memcpy(&pktsz, CMSG_DATA(cmsg), sizeof(pktsz));
+			break;
+		}
+	}
+
+	return pktsz;
+}
 #endif

 void
@@ -877,9 +894,10 @@
 	struct mmsghdr *mmsg, *mhdr;
 	struct iovec *iov;
 	char *payload;
-
 #if defined(__linux__) && defined(UDP_GRO)
-	if (!fill && gro)
+	char *cmsgs;
+
+	if (gro && !fill)
 		paylen = IP_MAXPACKET;
 #endif

@@ -893,17 +911,29 @@
 		err(1, "calloc payload");
 	if (fill)
 		arc4random_buf(payload, packets * paylen);
+#if defined(__linux__) && defined(UDP_GRO)
+	if (gro && !fill &&
+	    (payload = calloc(packets, CMSG_SPACE(sizeof(int)))) == NULL)
+		err(1, "calloc cmsg");
+#endif

 	mhdr = mmsg;
 	while (packets > 0) {
 		mhdr->msg_hdr.msg_iov = iov;
 		mhdr->msg_hdr.msg_iovlen = 1;
+#if defined(__linux__) && defined(UDP_GRO)
+		if (gro && !fill) {
+			mhdr->msg_hdr.msg_control = cmsgs;
+			mhdr->msg_hdr.msg_controllen = CMSG_SPACE(sizeof(int));
+		}
+#endif
 		iov->iov_base = payload;
 		iov->iov_len = paylen;

 		mhdr++;
 		iov++;
 		payload += paylen;
+		cmsgs += CMSG_SPACE(sizeof(int));
 		packets--;
 	}

@@ -915,6 +945,7 @@
 {
 	free(mmsg->msg_hdr.msg_iov->iov_base);
 	free(mmsg->msg_hdr.msg_iov);
+	free(mmsg->msg_hdr.msg_control);
 	free(mmsg);
 }

@@ -1002,9 +1033,6 @@
 	struct mmsghdr *mmsg;
 	char *payload;
 	size_t udplen;
-#if defined(__linux__) && defined(UDP_GRO)
-	size_t total_received_payload = 0;
-#endif
 	ssize_t rcvlen;
 	socklen_t len;
 	int pkts;
@@ -1096,14 +1124,27 @@
 		}
 		timerclear(final);
 		bored = 0;
-		packet += pkts;
 #if defined(__linux__) && defined(UDP_GRO)
 		if (gro) {
-			int i;
-			for (i = 0; i < pkts; i++)
-				total_received_payload += mmsg[i].msg_len;
+			int i, packet_size;
+			/* XXX: assume that all msgs have the same GSO size */
+			for (i = 0; i < pkts; i++) {
+				packet_size = getgro_size(&mmsg[i].msg_hdr);
+				if (packet_size == 0) // XXX
+{
+printf("gro fail %u\n", mmsg[i].msg_len);
+					packet_size = mmsg[i].msg_len;
+}
+				else
+					printf("gro works\n");
+				packet += mmsg[i].msg_len / packet_size;
+				if (mmsg[i].msg_len % packet_size != 0)
+					packet++;
+			}
+			pkts = 0;
 		}
 #endif
+		packet += pkts;
 	}

 	if (gettimeofday(&end, NULL) == -1)
@@ -1117,11 +1158,6 @@
 		/* new final is duration without packets */
 		timersub(&tmp, final, final);
 	}
-#if defined(__linux__) && defined(UDP_GRO)
-	/* XXX: assume that all msgs will be of size rcvlen */
-	if (gro)
-		packet = total_received_payload / rcvlen;
-#endif
 	status_init("recv", syscall, packet, paylen, udp_family, &begin, &end);
 	if (mmsglen)
 		mmsg_free(mmsg);
 		
```
